### PR TITLE
Accept ssh-rsa key algorithms

### DIFF
--- a/ruckusconf
+++ b/ruckusconf
@@ -450,7 +450,7 @@ if { "$telnet" == "true" } {
     exit
   }
   #send_user " spawn ssh $admin@$device \n"
-  spawn ssh $username@$device
+  spawn ssh -oHostKeyAlgorithms=+ssh-rsa $username@$device
   expect {
     -re "assword:"  { send -- "$apasswd\r"
     }   "assword :" { send -- "$apasswd\r"


### PR DESCRIPTION
Accept ssh-rsa key algorithms as newer ssh clients deny them by default.